### PR TITLE
Database / H2 / Use server mode

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,14 +34,13 @@ spring:
   application:
     name: GeoNetwork
   datasource:
-    url: jdbc:postgresql://localhost:5432/gn
-    driverClassName: org.postgresql.Driver
+    #    url: jdbc:postgresql://localhost:5432/gn
+    #    driverClassName: org.postgresql.Driver
+    #    url: jdbc:h2:mem:gn5
+    url: jdbc:h2:~/gn;AUTO_SERVER=TRUE
+    driverClassName: org.h2.Driver
     username: www-data
     password: www-data
-  #      url: jdbc:h2:mem:gn5
-  #      driverClassName: org.h2.Driver
-  #      username: sa
-  #      password: password
   jpa:
     open-in-view: false
     database-platform: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
Use H2 server mode to allow connection to GeoNetwork default H2 database. For this, add `;AUTO_SERVER=TRUE` to https://github.com/geonetwork/core-geonetwork/blob/main/pom.xml#L1511 or use `-Ddb.name=~/gn;AUTO_SERVER=TRUE` when starting Geonetwork.


See https://h2database.com/html/features.html#auto_mixed_mode